### PR TITLE
Adding NAMESPACE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 TEST?=$$(go list ./... | grep -v 'vendor')
 HOSTNAME=patrickcping
+NAMESPACE=pingidentity
 NAME=pingone
 BINARY=terraform-provider-${NAME}
-VERSION=0.2
-OS_ARCH=darwin_amd64
+VERSION=0.0.2
+OS_ARCH=linux_amd64
 
 default: install
 
@@ -25,12 +26,12 @@ release:
 	GOOS=windows GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_windows_amd64
 
 install: build
-	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAME}/${VERSION}/${OS_ARCH}
-	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAME}/${VERSION}/${OS_ARCH}
+	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
+	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 
 test: 
 	go test -i $(TEST) || exit 1                                                   
 	echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4                    
 
 testacc: 
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m   
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=patrickcping
 NAMESPACE=pingidentity
 NAME=pingone
 BINARY=terraform-provider-${NAME}
-VERSION=0.0.2
+VERSION=0.2
 OS_ARCH=linux_amd64
 
 default: install


### PR DESCRIPTION
Adding NAMESPACE allows you to run terraform from examples without dev dependencies.